### PR TITLE
Add support for deleting messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -225,7 +225,7 @@ module.exports = function (file, opts) {
 
       const nullBytes = Buffer.alloc(length)
       nullBytes.copy(buffer, block_start+2)
-      cb(null)
+      raf.write(~~(offset/block), buffer, cb)
     })
   }
 

--- a/index.js
+++ b/index.js
@@ -118,7 +118,6 @@ module.exports = function (file, opts) {
     if(offset >= length) return cb()
     var record_start = offset%block
     var block_start = offset - record_start
-    console.log("getting block", ~~(offset/block))
     getBlock(~~(offset/block), function (err, buffer) {
       if(err) return cb(err)
       var length = buffer.readUInt16LE(record_start)
@@ -225,7 +224,6 @@ module.exports = function (file, opts) {
 
       const nullBytes = Buffer.alloc(length)
       nullBytes.copy(buffer, record_start+2)
-      console.log(`writing buffer, block start: ${block_start}, offset: ${offset}, block size: ${block}, length: ${length}`)
       raf.write(block_start, buffer, cb)
     })
   }

--- a/stream.js
+++ b/stream.js
@@ -103,7 +103,7 @@ Stream.prototype._next = function () {
       }
       if(async) self.resume()
     })
-  async = true
+    async = true
   }
   if(returned) return self._next()
 }
@@ -115,9 +115,13 @@ Stream.prototype.isAtEnd = function () {
 
 Stream.prototype._format = function (result) {
   if(this.values) {
-    var value = this.blocks.codec.decode(this._buffer.slice(result.start, result.start + result.length))
-    if(this.seqs) this.sink.write({seq: result.offset, value: value})
-    else this.sink.write(value)
+    var data = this._buffer.slice(result.start, result.start + result.length)
+    if (!data.every(x => x === 0)) // skip deleted
+    {
+      var value = this.blocks.codec.decode(data)
+      if(this.seqs) this.sink.write({seq: result.offset, value: value})
+      else this.sink.write(value)
+    }
   }
   else
     this.sink.write(result.offset)

--- a/test/delete.js
+++ b/test/delete.js
@@ -1,0 +1,70 @@
+var tape = require('tape')
+var Offset = require('../')
+
+tape('simple', function (t) {
+  var file = '/tmp/offset-test_'+Date.now()+'.log'
+  var db = Offset(file, {block: 64*1024})
+
+  db.append(Buffer.from('hello world'), function (err, offset1) {
+    if(err) throw err
+    t.equal(offset1, db.since.value)
+    //NOTE: 'hello world'.length + 8 (start frame + end frame)
+    t.equal(db.since.value, 0)
+    db.append(Buffer.from('hello offset db'), function (err, offset2) {
+      if(err) throw err
+      t.ok(offset2 > offset1)
+      t.equal(offset2, db.since.value)
+      db.get(offset1, function (err, b) {
+        if(err) throw err
+        t.equal(b.toString(), 'hello world', 'read 1st value')
+
+        db.get(offset2, function (err, b2) {
+          if(err) throw err
+          t.equal(b2.toString(), 'hello offset db')
+          db.del(offset1, function (err) {
+            t.error(err)
+            db.get(offset1, function (err) {
+              t.ok(err)
+              t.equal(err.message, 'item has been deleted')
+              t.end()
+            })
+          })
+        })
+      })
+    })
+  })
+})
+
+function collect (cb) {
+  return {
+    array: [],
+    paused: false,
+    write: function (v) { this.array.push(v) },
+    end: function (err) {
+      this.ended = err || true
+      cb(err, this.array)
+    }
+  }
+}
+
+tape('stream delete', function(t) {
+  var file = '/tmp/offset-test_'+Date.now()+'.log'
+  var db = Offset(file, {block: 64*1024})
+
+  var b2 = Buffer.from('hello offset db')
+  
+  db.append(Buffer.from('hello world'), function (err, offset1) {
+    if(err) throw err
+    db.append(b2, function (err, offset2) {
+      if(err) throw err
+      db.del(offset1, function (err) {
+        t.error(err)
+        db.stream({seqs: false}).pipe(collect(function (err, ary) {
+          t.notOk(err)
+          t.deepEqual(ary, [b2])
+          db.onDrain(t.end)
+        }))
+      })
+    })
+  })
+})

--- a/test/delete.js
+++ b/test/delete.js
@@ -1,35 +1,72 @@
 var tape = require('tape')
+var fs = require('fs')
 var Offset = require('../')
 
-tape('simple', function (t) {
-  var file = '/tmp/offset-test_'+Date.now()+'.log'
-  var db = Offset(file, {block: 64*1024})
+var v1 = Buffer.from('hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world hello world')
+var v2 = Buffer.from('hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db hello offset db')
+var v3 = Buffer.from('hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db hello offsetty db')
 
-  db.append(Buffer.from('hello world'), function (err, offset1) {
+tape('simple', function (t) {
+  var file = '/tmp/fao-test_del.log'
+  try { fs.unlinkSync(file) } catch (_) {}
+  var db = Offset(file, {block: 2*1024})
+
+  db.append(v1, function (err, offset1) {
     if(err) throw err
     t.equal(offset1, db.since.value)
-    //NOTE: 'hello world'.length + 8 (start frame + end frame)
     t.equal(db.since.value, 0)
-    db.append(Buffer.from('hello offset db'), function (err, offset2) {
+    db.append(v2, function (err, offset2) {
       if(err) throw err
-      t.ok(offset2 > offset1)
-      t.equal(offset2, db.since.value)
-      db.get(offset1, function (err, b) {
+      db.append(v3, function (err, offset3) {
         if(err) throw err
-        t.equal(b.toString(), 'hello world', 'read 1st value')
-
-        db.get(offset2, function (err, b2) {
+        t.ok(offset3 > offset2)
+        t.equal(offset3, db.since.value)
+        db.get(offset1, function (err, b) {
           if(err) throw err
-          t.equal(b2.toString(), 'hello offset db')
-          db.del(offset1, function (err) {
-            t.error(err)
-            db.get(offset1, function (err) {
-              t.ok(err)
-              t.equal(err.message, 'item has been deleted')
-              t.end()
+          t.equal(b.toString(), v1.toString())
+
+          db.get(offset2, function (err, b2) {
+            if(err) throw err
+            t.equal(b2.toString(), v2.toString())
+
+            db.get(offset3, function (err, b3) {
+              if(err) throw err
+              t.equal(b3.toString(), v3.toString())
+
+              db.del(offset2, function (err) {
+                t.error(err)
+
+                db.get(offset2, function (err, bdel) {
+                  t.ok(err)
+                  t.equal(err.message, 'item has been deleted')
+                  t.end()
+                })
+              })
             })
           })
         })
+      })
+    })
+  })
+})
+
+tape('simple reread', function (t) {
+  var file = '/tmp/fao-test_del.log'
+  var db = Offset(file, {block: 2*1024})
+
+  db.get(0, function (err, b) {
+    if(err) throw err
+    t.equal(b.toString(), v1.toString())
+
+    db.get(v1.length+2+2, function (err, b2) {
+      t.ok(err)
+      t.equal(err.message, 'item has been deleted')
+
+      db.get(v1.length+2+2+v2.length+2+2, function (err, b3) {
+        if(err) throw err
+        t.equal(b3.toString(), v3.toString())
+
+        t.end()
       })
     })
   })

--- a/test/delete.js
+++ b/test/delete.js
@@ -33,10 +33,10 @@ tape('simple', function (t) {
               if(err) throw err
               t.equal(b3.toString(), v3.toString())
 
-              db.del(offset2, function (err) {
+              db.del(offset3, function (err) {
                 t.error(err)
 
-                db.get(offset2, function (err, bdel) {
+                db.get(offset3, function (err, bdel) {
                   t.ok(err)
                   t.equal(err.message, 'item has been deleted')
                   t.end()
@@ -54,6 +54,40 @@ tape('simple reread', function (t) {
   var file = '/tmp/fao-test_del.log'
   var db = Offset(file, {block: 2*1024})
 
+  var offset1 = 0
+  var offset2 = v1.length+2+2
+  var offset3 = v1.length+2+2+v2.length+2+2
+
+  db.get(offset1, function (err, b) {
+    if(err) throw err
+    t.equal(b.toString(), v1.toString())
+
+    db.get(offset2, function (err, b2) {
+      if(err) throw err
+      t.equal(b2.toString(), v2.toString())
+
+      db.get(offset3, function (err) {
+        t.ok(err)
+        t.equal(err.message, 'item has been deleted')
+
+        db.del(offset2, function (err) {
+          t.error(err)
+
+          db.get(offset2, function (err, bdel) {
+            t.ok(err)
+            t.equal(err.message, 'item has been deleted')
+            t.end()
+          })
+        })
+      })
+    })
+  })
+})
+
+tape('simple reread 2', function (t) {
+  var file = '/tmp/fao-test_del.log'
+  var db = Offset(file, {block: 2*1024})
+
   db.get(0, function (err, b) {
     if(err) throw err
     t.equal(b.toString(), v1.toString())
@@ -62,12 +96,7 @@ tape('simple reread', function (t) {
       t.ok(err)
       t.equal(err.message, 'item has been deleted')
 
-      db.get(v1.length+2+2+v2.length+2+2, function (err, b3) {
-        if(err) throw err
-        t.equal(b3.toString(), v3.toString())
-
-        t.end()
-      })
+      t.end()
     })
   })
 })

--- a/test/stream.js
+++ b/test/stream.js
@@ -1,4 +1,3 @@
-
 var tape = require('tape')
 var fs = require('fs')
 var FlumeLogRaf = require('../')


### PR DESCRIPTION
This is a port of the changes @christianbundy did to [flumelog-offset](https://github.com/flumedb/flumelog-offset). I changed some terminology in the get function because I found the names highly confusing :) 

I'm not super happy with the eager write (raf.write(block_start, buffer, cb)), the problem is that this doesn't fit that well with the append pattern that has knowledge of blocks to be written. I'll push some changes for that, would be very happy with some feedback on the strategy first though.